### PR TITLE
Improve menu handling and prevent duplicate episodes

### DIFF
--- a/Scripts/scraper_utils.py
+++ b/Scripts/scraper_utils.py
@@ -808,20 +808,34 @@ def insert_season(series_id, season_number, connection=None, db_path=None):
 
 # Función para insertar un nuevo episodio
 def insert_episode(season_id, episode_number, title, connection=None, db_path=None):
-    """Inserta un nuevo episodio en la base de datos."""
+    """Inserta un nuevo episodio en la base de datos evitando duplicados."""
     close_connection = False
     if connection is None:
         connection = connect_db(db_path)
         close_connection = True
 
+    # Comprobar si el episodio ya existe
+    exists, existing_id = episode_exists(
+        season_id,
+        episode_number,
+        title,
+        connection=connection,
+        db_path=db_path,
+    )
+    if exists:
+        return existing_id
+
     cursor = connection.cursor()
     episode_id = None
 
     try:
-        cursor.execute('''
+        cursor.execute(
+            '''
             INSERT INTO series_episodes (season_id, episode, title)
             VALUES (?, ?, ?)
-        ''', (season_id, episode_number, title))
+            ''',
+            (season_id, episode_number, title),
+        )
         episode_id = cursor.lastrowid
         connection.commit()
 

--- a/Scripts/update_episodes_premiere.py
+++ b/Scripts/update_episodes_premiere.py
@@ -987,7 +987,7 @@ def process_premiere_episodes(db_path=None):
 
 
 # Punto de entrada principal
-if __name__ == "____main__":
+if __name__ == "__main__":
     # Configurar argumentos de línea de comandos
     parser = argparse.ArgumentParser(description='Actualización de episodios de estreno')
     parser.add_argument('--max-workers', type=int, help='Número máximo de workers para procesamiento paralelo')

--- a/main.py
+++ b/main.py
@@ -7,8 +7,16 @@ import tkinter as tk
 from tkinter import filedialog, messagebox
 from datetime import datetime
 
+# Ensure Scripts directory is in sys.path
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "Scripts")
+if SCRIPT_DIR not in sys.path:
+    sys.path.append(SCRIPT_DIR)
+
 # Import scraper modules
 from scraper_utils import setup_database, connect_db, PROJECT_ROOT, setup_logger
+from direct_dw_series_scraper import process_all_series
+from update_episodes_premiere import process_premiere_episodes
+from update_episodes_updated import process_updated_episodes
 
 # Configure logger
 logger = setup_logger("main", "main.log")
@@ -125,9 +133,11 @@ def series_scraper_menu():
     print("2. Start scraping from specific page")
     print("3. Scrape specific number of pages")
     print("4. Reset progress and start from page 1")
-    print("5. Back to main menu")
+    print("5. Update latest episodes")
+    print("6. Update recently updated episodes")
+    print("7. Back to main menu")
 
-    choice = input("\\nEnter your choice (1-5): ")
+    choice = input("\\nEnter your choice (1-7): ")
 
     if choice == '1':
         # Start from page 1
@@ -170,6 +180,18 @@ def series_scraper_menu():
         return series_scraper_menu()
 
     elif choice == '5':
+        # Update latest episodes
+        process_premiere_episodes()
+        input("\\nUpdate completed. Press Enter to continue...")
+        return series_scraper_menu()
+
+    elif choice == '6':
+        # Update recently updated episodes
+        process_updated_episodes()
+        input("\\nUpdate completed. Press Enter to continue...")
+        return series_scraper_menu()
+
+    elif choice == '7':
         return
 
     else:


### PR DESCRIPTION
## Summary
- Ensure main script can import scraper modules by adding the `Scripts` directory to `sys.path`
- Extend series menu with options to update latest and recently updated episodes
- Avoid duplicate episode entries by checking for existing records before insertion
- Fix `update_episodes_premiere` entry point so the script runs correctly

## Testing
- `python -m py_compile main.py Scripts/scraper_utils.py Scripts/update_episodes_premiere.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2ddc0200c832895f2d9a491c22da0