### PR TITLE
Add Windows batch helper for environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Virtual environment
+venv/
+
+# Python cache files
+__pycache__/
+*.py[cod]
+
+# Logs
+*.log
+logs/

--- a/Readme.md
+++ b/Readme.md
@@ -1,47 +1,39 @@
-# React + TypeScript + Vite
+# HDFull Scrapers
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project contains utilities to scrape data from the HDFull website and manage the collected information.
 
-Currently, two official plugins are available:
+## Windows setup
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+A convenience batch script is included to create an isolated Python environment, install dependencies and launch the main application.
 
-## Expanding the ESLint configuration
+1. Double-click `run.bat` (or execute it from a command prompt).
+2. The script will create a `venv` virtual environment if it does not yet exist.
+3. Required packages from `requirements.txt` will be installed.
+4. Finally the script runs `python main.py`. Any command-line arguments passed to the batch file are forwarded to the Python program.
 
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
+Example:
 
-- Configure the top-level `parserOptions` property like this:
+```bat
+run.bat --series --start-page 2
+```
 
+This executes the series scraper starting at page 2.
 
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+## Manual setup (non-Windows)
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+If you are running the project on another platform, perform the steps manually:
 
-// eslint.config.js
-import react from 'eslint-plugin-react'
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python main.py
+```
 
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
+## Repository structure
+
+- `main.py` – Entry point that displays the application menu or accepts command line arguments.
+- `Scripts/` – Helper modules used by the scraper.
+- `run.bat` – Windows helper to bootstrap the environment and execute `main.py`.
+
+Logs and the virtual environment are ignored by git.

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,18 @@
+@echo off
+REM Ensure working directory is the script location
+cd /d %~dp0
+
+REM Create virtual environment if it doesn't exist
+if not exist venv (
+    python -m venv venv
+)
+
+REM Activate virtual environment
+call venv\Scripts\activate
+
+REM Upgrade pip and install dependencies
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+
+REM Run the main application, forwarding any arguments
+python main.py %*


### PR DESCRIPTION
## Summary
- add `run.bat` to bootstrap a virtual environment, install dependencies and run the main scraper
- rewrite README with instructions for using the batch file and manual setup
- add `.gitignore` to exclude `venv`, logs and Python caches

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2e0b9aa3083289a62f09919fd2c8b