### PR TITLE
Fix circular import in update episodes script

### DIFF
--- a/Scripts/update_episodes_updated.py
+++ b/Scripts/update_episodes_updated.py
@@ -16,10 +16,8 @@ from scraper_utils import (
     save_progress, load_progress, extract_links,
     insert_links_batch, clear_cache, find_series_by_title_year,
     season_exists, episode_exists, insert_series, insert_season,
-    insert_episode, BASE_URL, MAX_WORKERS, MAX_RETRIES
+    insert_episode, BASE_URL, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT
 )
-
-from main import PROJECT_ROOT
 
 # Configuración específica para este script
 SCRIPT_NAME = "update_episodes_updated"


### PR DESCRIPTION
## Summary
- import `PROJECT_ROOT` from `scraper_utils` to avoid circular dependency

## Testing
- `python main.py --help`
- `python -m py_compile main.py Scripts/update_episodes_updated.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3c8eccd848328a08bdc0828a5ee60