### PR TITLE
Fix main imports to use Scripts package

### DIFF
--- a/Scripts/direct_dw_series_scraper.py
+++ b/Scripts/direct_dw_series_scraper.py
@@ -15,13 +15,21 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException, StaleElementReferenceException
 
 # ver1.9
-# Importar utilidades compartidas
-from scraper_utils import (
-    setup_logger, create_driver, connect_db, login, setup_database,
-    save_progress, load_progress, clear_cache, find_series_by_title_year,
-    season_exists, episode_exists, insert_series, insert_season,
-    insert_episode, BASE_URL, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT
-)
+# Import shared utilities (compatible when run as script or module)
+try:
+    from .scraper_utils import (
+        setup_logger, create_driver, connect_db, login, setup_database,
+        save_progress, load_progress, clear_cache, find_series_by_title_year,
+        season_exists, episode_exists, insert_series, insert_season,
+        insert_episode, BASE_URL, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
+    )
+except ImportError:  # pragma: no cover - fallback when executed directly
+    from scraper_utils import (
+        setup_logger, create_driver, connect_db, login, setup_database,
+        save_progress, load_progress, clear_cache, find_series_by_title_year,
+        season_exists, episode_exists, insert_series, insert_season,
+        insert_episode, BASE_URL, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
+    )
 
 # Configuración específica para este script
 SCRIPT_NAME = "direct_dw_series_scraper"

--- a/main.py
+++ b/main.py
@@ -5,14 +5,9 @@ import argparse
 import logging
 from datetime import datetime
 
-# Ensure Scripts directory is in sys.path
-SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "Scripts")
-if SCRIPT_DIR not in sys.path:
-    sys.path.append(SCRIPT_DIR)
-
-# Import scraper modules
-import scraper_utils
-from scraper_utils import (
+# Import scraper modules from the Scripts package
+from Scripts import scraper_utils
+from Scripts.scraper_utils import (
     setup_database,
     connect_db,
     PROJECT_ROOT,
@@ -25,7 +20,7 @@ from scraper_utils import (
 import menu_scrapers
 
 # Direct series scraper is still available via CLI arguments
-from direct_dw_series_scraper import process_all_series
+from Scripts.direct_dw_series_scraper import process_all_series
 
 # Configure logger
 logger = setup_logger("main", "main.log")


### PR DESCRIPTION
## Summary
- import utilities from Scripts package directly in `main.py`
- support both package and script execution for `direct_dw_series_scraper`

## Testing
- `python -m py_compile main.py Scripts/direct_dw_series_scraper.py`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c3feff4534832885b57918ae78dc3d