### PR TITLE
Update Dontorrent base URLs to lighting domain

### DIFF
--- a/Scripts/torrent_dw_films_scraper.py
+++ b/Scripts/torrent_dw_films_scraper.py
@@ -36,7 +36,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-BASE_URL = "https://dontorrent.schule/pelicula/"
+# Base URL del sitio Dontorrent para películas
+BASE_URL = "https://dontorrent.lighting/pelicula/"
 
 # Path to the database
 db_path = r'D:/Workplace/HdfullScrappers/Scripts/torrent_dw_db.db'

--- a/Scripts/torrent_dw_series_scraper.py
+++ b/Scripts/torrent_dw_series_scraper.py
@@ -37,6 +37,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# URL base del sitio Dontorrent para series
+BASE_URL = "https://dontorrent.lighting/serie/"
+
 # Path to the database
 db_path = r'D:/Workplace/HdfullScrappers/Scripts/torrent_dw_db.db'
 
@@ -424,7 +427,7 @@ def scrape_series(start_id=1, max_consecutive_failures=10):
 
     try:
         while True:
-            series_url = f"https://dontorrent.schule/serie/{current_id}/{current_id}/"
+            series_url = f"{BASE_URL}{current_id}/{current_id}/"
             logger.info(f"Extrayendo: {series_url}")
 
             success = False


### PR DESCRIPTION
## Summary
- Switch Dontorrent scrapers to the `dontorrent.lighting` domain for movies and series
- Centralize series URL construction with a new `BASE_URL` constant

## Testing
- `python -m py_compile Scripts/torrent_dw_films_scraper.py Scripts/torrent_dw_series_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68c407a00e708328bd196b66a7049a32