### PR TITLE
Use shared database paths for direct and torrent scrapers

### DIFF
--- a/Scripts/db_setup.py
+++ b/Scripts/db_setup.py
@@ -2,8 +2,22 @@ import os
 import sqlite3
 import logging
 
-# Determinar la ruta raíz del proyecto sin depender de `main`
-PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Obtener rutas compartidas desde scraper_utils para mantener consistencia
+try:  # pragma: no cover - fallback cuando se ejecuta como script
+    from .scraper_utils import (
+        DB_PATH as DIRECT_DB_PATH,
+        TORRENT_DB_PATH,
+        PROJECT_ROOT,
+    )
+except ImportError:  # pragma: no cover
+    from scraper_utils import (
+        DB_PATH as DIRECT_DB_PATH,
+        TORRENT_DB_PATH,
+        PROJECT_ROOT,
+    )
+
+# Asegurar que el directorio de logs existe
+os.makedirs(os.path.join(PROJECT_ROOT, "logs"), exist_ok=True)
 
 # Configuración del logging
 logging.basicConfig(
@@ -11,14 +25,10 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s',
     handlers=[
         logging.FileHandler(os.path.join(PROJECT_ROOT, "logs", "db_setup.log")),
-        logging.StreamHandler()
-    ]
+        logging.StreamHandler(),
+    ],
 )
 logger = logging.getLogger(__name__)
-
-# Rutas de las bases de datos
-DIRECT_DB_PATH = os.path.join(PROJECT_ROOT, "Scripts", "direct_dw_db.db")
-TORRENT_DB_PATH = os.path.join(PROJECT_ROOT, "Scripts", "torrent_dw_db.db")
 
 
 def create_direct_db(db_path=None):

--- a/Scripts/direct_dw_films_scraper.py
+++ b/Scripts/direct_dw_films_scraper.py
@@ -78,8 +78,13 @@ if not os.path.exists(progress_dir):
 # Archivo para guardar el progreso
 progress_file = os.path.join(progress_dir, "movie_progress.json")
 
-# Ruta de la base de datos
-db_path = r'D:/Workplace/HdfullScrappers/Scripts/direct_dw_db.db'
+# Ruta de la base de datos (usando configuración compartida)
+try:  # pragma: no cover - compatible al ejecutarse como script o módulo
+    from .scraper_utils import DB_PATH
+except ImportError:  # pragma: no cover
+    from scraper_utils import DB_PATH
+
+db_path = DB_PATH
 
 # Contador de reinicios del script
 restart_count = 0

--- a/Scripts/torrent_dw_films_scraper.py
+++ b/Scripts/torrent_dw_films_scraper.py
@@ -39,8 +39,13 @@ logger = logging.getLogger(__name__)
 # Base URL del sitio Dontorrent para películas
 BASE_URL = "https://dontorrent.lighting/pelicula/"
 
-# Path to the database
-db_path = r'D:/Workplace/HdfullScrappers/Scripts/torrent_dw_db.db'
+# Path to the database (shared configuration)
+try:  # pragma: no cover - compatible con ejecución como script o módulo
+    from .scraper_utils import TORRENT_DB_PATH
+except ImportError:  # pragma: no cover
+    from scraper_utils import TORRENT_DB_PATH
+
+db_path = TORRENT_DB_PATH
 
 # Headers (para evitar ser bloqueado)
 headers = {

--- a/Scripts/torrent_dw_series_scraper.py
+++ b/Scripts/torrent_dw_series_scraper.py
@@ -40,8 +40,13 @@ logger = logging.getLogger(__name__)
 # URL base del sitio Dontorrent para series
 BASE_URL = "https://dontorrent.lighting/serie/"
 
-# Path to the database
-db_path = r'D:/Workplace/HdfullScrappers/Scripts/torrent_dw_db.db'
+# Path to the database (shared configuration)
+try:  # pragma: no cover - compatible con ejecución como script o módulo
+    from .scraper_utils import TORRENT_DB_PATH
+except ImportError:  # pragma: no cover
+    from scraper_utils import TORRENT_DB_PATH
+
+db_path = TORRENT_DB_PATH
 
 # Headers (para evitar ser bloqueado)
 headers = {


### PR DESCRIPTION
## Summary
- Align database setup with `scraper_utils` paths for consistency
- Reuse shared DB path in direct download film scraper
- Reuse shared torrent DB path in film and series scrapers

## Testing
- `python -m py_compile HdfullScrappers/Scripts/db_setup.py HdfullScrappers/Scripts/direct_dw_films_scraper.py HdfullScrappers/Scripts/torrent_dw_films_scraper.py HdfullScrappers/Scripts/torrent_dw_series_scraper.py`
- `python HdfullScrappers/Scripts/db_setup.py <<'EOF'

EOF`

------
https://chatgpt.com/codex/tasks/task_e_68c4172313208328b4640f7c7fcbef6b