### PR TITLE
Track existing link totals via database counts

### DIFF
--- a/Scripts/torrent_dw_series_scraper.py
+++ b/Scripts/torrent_dw_series_scraper.py
@@ -45,6 +45,28 @@ except ImportError:  # pragma: no cover
 
 db_path = TORRENT_DB_PATH
 
+# Count existing torrent files for a given type
+def get_total_saved_count(content_type):
+    """Return number of torrent_files records for a given content type."""
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT COUNT(tf.id)
+            FROM torrent_files tf
+            JOIN torrent_downloads td ON tf.torrent_id = td.id
+            WHERE td.type = ?
+            """,
+            (content_type,),
+        )
+        count = cursor.fetchone()[0]
+    except Exception:
+        count = 0
+    finally:
+        if 'conn' in locals():
+            conn.close()
+    return count
 # Headers (para evitar ser bloqueado)
 headers = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
@@ -120,19 +142,21 @@ def initialize_database():
 
 
 def load_progress():
-    """Carga el progreso guardado desde el archivo JSON."""
+    """Carga el progreso guardado desde el archivo JSON y sincroniza el total con la base de datos."""
+    db_total = get_total_saved_count('series')
     if os.path.exists(progress_file):
         try:
             with open(progress_file, 'r') as f:
                 progress_data = json.load(f)
+                progress_data['total_saved'] = db_total
                 logger.info(
-                    f"Progreso cargado: ID actual = {progress_data.get('current_id', 1)}, Total guardado = {progress_data.get('total_saved', 0)}")
+                    f"Progreso cargado: ID actual = {progress_data.get('current_id', 1)}, Total guardado = {db_total}")
                 return progress_data
         except Exception as e:
             logger.error(f"Error al cargar el archivo de progreso: {str(e)}")
 
     # Si no hay archivo o hay un error, devolver valores predeterminados
-    return {"current_id": 1, "total_saved": 0, "last_update": time.strftime("%Y-%m-%d %H:%M:%S")}
+    return {"current_id": 1, "total_saved": db_total, "last_update": time.strftime("%Y-%m-%d %H:%M:%S")}
 
 
 def save_progress(current_id, total_saved):
@@ -408,11 +432,11 @@ def insert_data(db_conn, series_title, season_number, quality, episodes):
 
         db_conn.commit()
         logger.info(f"Se añadieron {episodes_added} episodios para la serie '{series_title}' con calidad {quality}.")
-        return episodes_added > 0
+        return episodes_added
     except Exception as e:
         db_conn.rollback()
         logger.error(f"Error al insertar datos: {e}")
-        return False
+        return 0
 
 
 def scrape_series(start_id=1, max_consecutive_failures=10):
@@ -423,7 +447,7 @@ def scrape_series(start_id=1, max_consecutive_failures=10):
     total_saved = progress_data.get("total_saved", 0)
     next_id = current_id
 
-    logger.info(f"Iniciando scraping desde ID: {current_id}, series guardadas anteriormente: {total_saved}")
+    logger.info(f"Iniciando scraping desde ID: {current_id}, archivos guardados anteriormente: {total_saved}")
 
     conn = sqlite3.connect(db_path)
     consecutive_failures = 0
@@ -437,10 +461,13 @@ def scrape_series(start_id=1, max_consecutive_failures=10):
             for attempt in range(3):
                 series_title, season_number, quality, episodes = scrape_series_details(series_url)
                 if series_title and episodes:
-                    if insert_data(conn, series_title, season_number, quality, episodes):
+                    episodes_added = insert_data(conn, series_title, season_number, quality, episodes)
+                    if episodes_added:
                         logger.info(f"Guardado: {series_title} - Temporada {season_number} con calidad {quality}")
-                        total_saved += 1
+                        total_saved += episodes_added
                         consecutive_failures = 0  # Reiniciar contador de fallos
+                    else:
+                        logger.info(f"No guardado: {series_title} - Temporada {season_number} con calidad {quality}")
                     success = True
                     break
                 else:
@@ -477,7 +504,7 @@ def scrape_series(start_id=1, max_consecutive_failures=10):
     finally:
         # Guardar progreso final
         save_progress(next_id, total_saved)
-        logger.info(f"Proceso completado o interrumpido. Se guardaron {total_saved} series en la base de datos.")
+        logger.info(f"Proceso completado o interrumpido. Se guardaron {total_saved} archivos de torrent en la base de datos.")
         conn.close()
 
 


### PR DESCRIPTION
## Summary
- compute current torrent file totals for movies and series from the database before scraping
- mirror this database-backed counting in direct download scrapers, saving totals in progress files
- log final saved link totals for torrents and direct downloads

## Testing
- `python -m py_compile Scripts/torrent_dw_films_scraper.py Scripts/torrent_dw_series_scraper.py Scripts/direct_dw_films_scraper.py Scripts/direct_dw_series_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68c42094fa908328812e95bb4aed51f7