### PR TITLE
Improve Selenium stability for movie scrapers

### DIFF
--- a/Scripts/scraper_utils.py
+++ b/Scripts/scraper_utils.py
@@ -185,7 +185,9 @@ def create_driver(headless=True):
         driver = webdriver.Chrome(service=service, options=options)
 
     # Configurar timeouts
-    driver.set_page_load_timeout(30)
+    # Aumentamos el tiempo máximo de carga de página para evitar
+    # errores frecuentes de "Timed out receiving message from renderer"
+    driver.set_page_load_timeout(60)
     driver.implicitly_wait(5)
 
     return driver


### PR DESCRIPTION
## Summary
- add `load_page` helper with retries and optional driver recreation
- use `load_page` to fetch movie pages and listings
- extend Chrome page load timeout to reduce renderer timeouts

## Testing
- `python -m py_compile Scripts/update_movies_updated.py Scripts/update_movies_premiere.py Scripts/scraper_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5b68eb4508328924621153feb7fef