### PR TITLE
Improve episode update scroll performance

### DIFF
--- a/Scripts/update_episodes_updated.py
+++ b/Scripts/update_episodes_updated.py
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 
 # Importar utilidades compartidas
 from scraper_utils import (
@@ -62,10 +63,8 @@ def get_episode_urls_from_updated_page(driver):
     logger.info("Obteniendo URLs de episodios actualizados...")
     try:
         driver.get(UPDATED_EPISODES_URL)
-        time.sleep(3)  # Esperar a que se cargue la página y el contenido dinámico
 
-        # El hash en la URL ya debería seleccionar la pestaña "Actualizados",
-        # por lo que evitamos el clic adicional que a veces falla.
+        # Esperar a que el contenedor de episodios esté disponible en lugar de usar un sleep fijo
         try:
             WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located((By.ID, "episodes-content"))
@@ -74,54 +73,46 @@ def get_episode_urls_from_updated_page(driver):
             logger.error(f"Timeout esperando el contenedor de episodios: {e}")
             return []
 
-        # Obtener todos los episodios con scroll infinito
         episode_urls = []
         last_count = 0
-        no_new_results_count = 0
-        max_no_new_results = 5  # Número máximo de intentos sin nuevos resultados antes de parar
+        no_new_results = 0
+        max_no_new_results = 3  # Número máximo de intentos sin nuevos resultados antes de parar
         max_scroll_attempts = 50  # Límite de scroll para evitar bucles infinitos
 
-        # Conjunto para evitar duplicados
         seen_urls = set()
-
         scroll_attempt = 0
-        # Bucle para hacer scroll hasta que no haya más episodios
-        while scroll_attempt < max_scroll_attempts:
-            # Obtener los episodios actuales
-            page_source = driver.page_source
-            soup = BeautifulSoup(page_source, "html.parser")
-            episode_divs = soup.find_all("div", class_="span-6 tt view show-view")
 
-            # Procesar los episodios visibles actualmente
+        while scroll_attempt < max_scroll_attempts and no_new_results < max_no_new_results:
+            episode_divs = driver.find_elements(By.CSS_SELECTOR, "div.span-6.tt.view.show-view")
             for episode_div in episode_divs:
-                link_tag = episode_div.find("a", href=re.compile(r"/episodio/"))
-                if link_tag:
-                    episode_href = link_tag['href']
-                    episode_url = BASE_URL + episode_href if not episode_href.startswith('http') else episode_href
-
-                    # Añadir solo si no lo hemos visto antes
+                try:
+                    link_tag = episode_div.find_element(By.CSS_SELECTOR, "a[href*='/episodio/']")
+                    episode_url = link_tag.get_attribute('href')
+                    if not episode_url.startswith('http'):
+                        episode_url = BASE_URL + episode_url
                     if episode_url not in seen_urls:
                         episode_urls.append(episode_url)
                         seen_urls.add(episode_url)
+                except Exception:
+                    continue
 
-            # Verificar si se encontraron nuevos episodios
             if len(episode_urls) == last_count:
-                no_new_results_count += 1
-                if no_new_results_count >= max_no_new_results:  # Si no hay nuevos resultados después de varios intentos, terminar
-                    logger.info(
-                        f"No se encontraron nuevos episodios después de {no_new_results_count} intentos. Terminando scroll.")
-                    break
+                no_new_results += 1
             else:
-                no_new_results_count = 0  # Reiniciar contador si se encontraron nuevos episodios
+                no_new_results = 0
                 last_count = len(episode_urls)
 
-            # Hacer scroll hacia abajo
             driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
             logger.debug(
                 f"Scroll {scroll_attempt + 1}/{max_scroll_attempts}: {len(episode_urls)} episodios encontrados")
 
-            # Esperar a que se carguen más contenidos
-            time.sleep(1)
+            try:
+                WebDriverWait(driver, 2).until(
+                    lambda d: len(d.find_elements(By.CSS_SELECTOR, "div.span-6.tt.view.show-view")) > last_count
+                )
+            except TimeoutException:
+                pass
+
             scroll_attempt += 1
 
         if scroll_attempt >= max_scroll_attempts:


### PR DESCRIPTION
## Summary
- avoid fixed delays and speed up infinite scroll by waiting for content dynamically
- add TimeoutException import

## Testing
- `python -m py_compile Scripts/update_episodes_updated.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5b76016fc83288e6277624adaf655