### PR TITLE
feat: unify link insertion logging

### DIFF
--- a/Scripts/direct_dw_films_scraper.py
+++ b/Scripts/direct_dw_films_scraper.py
@@ -480,13 +480,19 @@ def insert_data_into_db(movie):
                     INSERT INTO links_files_download (movie_id, server_id, language, link, quality_id)
                     VALUES (?, ?, ?, ?, ?)
                 ''', (movie_id, server_id, link["language"], link["link"], quality_id))
-                logger.debug(
-                    f"Enlace insertado: movie_id={movie_id}, server={link['server']}, language={link['language']}")
+                log_link_insertion(
+                    logger,
+                    movie_id=movie_id,
+                    server=link["server"],
+                    language=link["language"],
+                )
                 links_inserted += 1
 
             # Confirmar la transacción solo si todo fue exitoso
             connection.commit()
-            logger.info(f"Datos insertados en la base de datos para la película: {movie['Nombre']}")
+            logger.info(
+                f"Datos insertados en la base de datos para la película: {movie['Nombre']} ({links_inserted} enlaces)"
+            )
             return links_inserted
         except Exception as e:
             logger.error(f"Error al insertar datos en la base de datos: {e}")

--- a/Scripts/direct_dw_series_scraper.py
+++ b/Scripts/direct_dw_series_scraper.py
@@ -1541,8 +1541,12 @@ def save_series_to_db(series_data, series_exists=False, db_path=None):
                                 """,
                                 (series_id, server_id, link_data["language"], link_data["url"], quality_id, episode_id)
                             )
-                            logger.info(
-                                f"Nuevo enlace insertado para episodio {episode_number}: {link_data['server']} - {link_data['language']}")
+                            log_link_insertion(
+                                logger,
+                                episode_id=episode_id,
+                                server=link_data['server'],
+                                language=link_data['language'],
+                            )
                             with stats_lock:
                                 stats['new_links'] += 1
                             with total_saved_lock:
@@ -1550,7 +1554,8 @@ def save_series_to_db(series_data, series_exists=False, db_path=None):
                                 progress_data['total_saved'] = total_saved
                         else:
                             logger.debug(
-                                f"Enlace ya existe para episodio {episode_number}: {link_data['server']} - {link_data['language']}")
+                                f"Enlace ya existe: episode_id={episode_id}, server={link_data['server']}, language={link_data['language']}"
+                            )
 
         connection.commit()
         return True


### PR DESCRIPTION
## Summary
- add helper to standardize link insertion logs
- record inserted links for movies and episodes with consistent format
- log link counts after saving movie data

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c5b99013788328b160e54917e81c26