### PR TITLE
Add safe progress handling and graceful shutdown

### DIFF
--- a/Scripts/torrent_dw_films_scraper.py
+++ b/Scripts/torrent_dw_films_scraper.py
@@ -370,37 +370,33 @@ def scrape_movies(start_id=1, end_id=35000, max_consecutive_failures=10):
             movie_url = f"{BASE_URL}{movie_id}/"
             logger.info(f"Extrayendo: {movie_url}")
 
-            movie_data = get_movie_data(movie_url)
-            if movie_data:
-                if save_to_db(movie_data):
-                    logger.info(
-                        f"Guardado: {movie_data['title']} ({movie_data['year']}) - Calidad: {movie_data['quality']}")
-                    total_saved += 1
-                    consecutive_failures = 0  # Reiniciar contador de fallos
+            try:
+                movie_data = get_movie_data(movie_url)
+                if movie_data:
+                    if save_to_db(movie_data):
+                        logger.info(
+                            f"Guardado: {movie_data['title']} ({movie_data['year']}) - Calidad: {movie_data['quality']}")
+                        total_saved += 1
+                        consecutive_failures = 0
+                    else:
+                        logger.info(
+                            f"No guardado (posible duplicado): {movie_data['title']} - Calidad: {movie_data['quality']}")
                 else:
-                    logger.info(
-                        f"No guardado (posible duplicado): {movie_data['title']} - Calidad: {movie_data['quality']}")
-            else:
-                consecutive_failures += 1
-                logger.warning(
-                    f"Película no encontrada o datos incompletos para ID: {movie_id}. Fallos consecutivos: {consecutive_failures}")
+                    consecutive_failures += 1
+                    logger.warning(
+                        f"Película no encontrada o datos incompletos para ID: {movie_id}. Fallos consecutivos: {consecutive_failures}")
 
-                if consecutive_failures >= max_consecutive_failures:
-                    logger.error(
-                        f"Se alcanzó el límite de {max_consecutive_failures} fallos consecutivos. Finalizando el script.")
-                    next_id = movie_id + 1
-                    break
-
-            # Calcular siguiente ID
-            next_id = movie_id + 1
-
-            # Guardar progreso cada película o cuando hay un error
-            if movie_id % 1 == 0 or movie_data is None:
+                    if consecutive_failures >= max_consecutive_failures:
+                        logger.error(
+                            f"Se alcanzó el límite de {max_consecutive_failures} fallos consecutivos. Finalizando el script.")
+                        break
+            except Exception as e:
+                logger.error(f"Error al procesar la película ID {movie_id}: {e}")
+            finally:
+                next_id = movie_id + 1
                 save_progress(next_id, total_saved)
-
-            # Pausa aleatoria para evitar bloqueos (entre 1 y 3 segundos)
-            sleep_time = 1 + (movie_id % 2)
-            time.sleep(sleep_time)
+                sleep_time = 1 + (movie_id % 2)
+                time.sleep(sleep_time)
 
     except KeyboardInterrupt:
         logger.info("Script interrumpido por el usuario")


### PR DESCRIPTION
## Summary
- ensure movie worker saves progress and respects shutdown signals
- add per-item progress tracking to torrent scrapers
- safeguard series workers and wait for threads on shutdown

## Testing
- `python -m py_compile Scripts/direct_dw_films_scraper.py Scripts/torrent_dw_films_scraper.py Scripts/direct_dw_series_scraper.py Scripts/torrent_dw_series_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7fef44000832884306a3e09b4055d