### PR TITLE
Add graceful shutdown handling to update scripts

### DIFF
--- a/Scripts/graceful_shutdown.py
+++ b/Scripts/graceful_shutdown.py
@@ -1,0 +1,14 @@
+import signal
+import threading
+
+
+class GracefulShutdown:
+    """Utility to handle graceful shutdown via system signals."""
+
+    def __init__(self):
+        self.shutdown_event = threading.Event()
+        signal.signal(signal.SIGINT, self._handle_signal)
+        signal.signal(signal.SIGTERM, self._handle_signal)
+
+    def _handle_signal(self, signum, frame):
+        self.shutdown_event.set()


### PR DESCRIPTION
## Summary
- introduce `GracefulShutdown` utility with signal-based shutdown event
- integrate `shutdown_event` checks into movie and episode update scripts
- ensure connections close and progress saves in `finally` blocks

## Testing
- `python -m py_compile Scripts/update_movies_premiere.py Scripts/update_movies_updated.py Scripts/update_episodes_premiere.py Scripts/update_episodes_updated.py Scripts/graceful_shutdown.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7fef533248328a5464c4d203ef836