### PR TITLE
Ensure progress saved and wait for workers on shutdown

### DIFF
--- a/Scripts/torrent_dw_series_scraper.py
+++ b/Scripts/torrent_dw_series_scraper.py
@@ -459,46 +459,42 @@ def scrape_series(start_id=1, max_consecutive_failures=10):
             series_url = f"{BASE_URL}{current_id}/{current_id}/"
             logger.info(f"Extrayendo: {series_url}")
 
-            success = False
-            for attempt in range(3):
-                series_title, season_number, quality, episodes = scrape_series_details(series_url)
-                if series_title and episodes:
-                    episodes_added = insert_data(conn, series_title, season_number, quality, episodes)
-                    if episodes_added:
-                        logger.info(f"Guardado: {series_title} - Temporada {season_number} con calidad {quality}")
-                        total_saved += episodes_added
-                        consecutive_failures = 0  # Reiniciar contador de fallos
+            try:
+                success = False
+                for attempt in range(3):
+                    series_title, season_number, quality, episodes = scrape_series_details(series_url)
+                    if series_title and episodes:
+                        episodes_added = insert_data(conn, series_title, season_number, quality, episodes)
+                        if episodes_added:
+                            logger.info(f"Guardado: {series_title} - Temporada {season_number} con calidad {quality}")
+                            total_saved += episodes_added
+                            consecutive_failures = 0
+                        else:
+                            logger.info(f"No guardado: {series_title} - Temporada {season_number} con calidad {quality}")
+                        success = True
+                        break
                     else:
-                        logger.info(f"No guardado: {series_title} - Temporada {season_number} con calidad {quality}")
-                    success = True
-                    break
-                else:
-                    logger.warning(f"Intento {attempt + 1} fallido para ID: {current_id}")
-                    time.sleep(1 + attempt)  # Incrementar tiempo de espera en cada intento
+                        logger.warning(f"Intento {attempt + 1} fallido para ID: {current_id}")
+                        time.sleep(1 + attempt)
 
-            if not success:
-                consecutive_failures += 1
-                logger.warning(
-                    f"Serie no encontrada para ID: {current_id}. Fallos consecutivos: {consecutive_failures}")
+                if not success:
+                    consecutive_failures += 1
+                    logger.warning(
+                        f"Serie no encontrada para ID: {current_id}. Fallos consecutivos: {consecutive_failures}")
 
-                if consecutive_failures >= max_consecutive_failures:
-                    logger.error(
-                        f"Se alcanzó el límite de {max_consecutive_failures} fallos consecutivos. Finalizando el script.")
-                    next_id = current_id + 1
-                    break
-
-            # Calcular el próximo ID a procesar
-            next_id = current_id + 1
-
-            # Guardar progreso periódicamente o cuando hay un error
-            if current_id % 1 == 0 or not success:
+                    if consecutive_failures >= max_consecutive_failures:
+                        logger.error(
+                            f"Se alcanzó el límite de {max_consecutive_failures} fallos consecutivos. Finalizando el script.")
+                        next_id = current_id + 1
+                        break
+            except Exception as e:
+                logger.error(f"Error al procesar serie ID {current_id}: {e}")
+            finally:
+                next_id = current_id + 1
                 save_progress(next_id, total_saved)
-
-            # Pausa aleatoria para evitar bloqueos (entre 1 y 3 segundos)
-            sleep_time = 1 + random.random() * 2
-            time.sleep(sleep_time)
-
-            current_id = next_id
+                sleep_time = 1 + random.random() * 2
+                time.sleep(sleep_time)
+                current_id = next_id
     except KeyboardInterrupt:
         logger.info("Script interrumpido por el usuario")
         shutdown_event.set()


### PR DESCRIPTION
## Summary
- Ensure every movie worker task is finalized with progress saving and queue completion
- Persist progress for series and torrent scrapers with try/finally blocks
- Await worker completion when shutdown events are triggered

## Testing
- `python -m py_compile Scripts/direct_dw_films_scraper.py Scripts/direct_dw_series_scraper.py Scripts/torrent_dw_films_scraper.py Scripts/torrent_dw_series_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68c80918e494832886e62e5bb3116b81