### PR TITLE
Fix module imports for Scripts package

### DIFF
--- a/Scripts/torrent_dw_films_scraper.py
+++ b/Scripts/torrent_dw_films_scraper.py
@@ -13,7 +13,7 @@ import urllib3
 
 #ver:1.05
 # Obtener la ruta del proyecto desde las utilidades compartidas
-from scraper_utils import PROJECT_ROOT, get_shutdown_event
+from .scraper_utils import PROJECT_ROOT, get_shutdown_event, TORRENT_DB_PATH
 
 shutdown_event = get_shutdown_event()
 
@@ -39,11 +39,6 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://dontorrent.lighting/pelicula/"
 
 # Path to the database (shared configuration)
-try:  # pragma: no cover - compatible con ejecución como script o módulo
-    from .scraper_utils import TORRENT_DB_PATH
-except ImportError:  # pragma: no cover
-    from scraper_utils import TORRENT_DB_PATH
-
 db_path = TORRENT_DB_PATH
 
 # Count existing torrent files for a given type

--- a/Scripts/torrent_dw_series_scraper.py
+++ b/Scripts/torrent_dw_series_scraper.py
@@ -14,7 +14,7 @@ import urllib3
 
 #ver:1.05
 # Obtener la ruta del proyecto desde las utilidades compartidas
-from scraper_utils import PROJECT_ROOT, get_shutdown_event
+from .scraper_utils import PROJECT_ROOT, get_shutdown_event, TORRENT_DB_PATH
 
 shutdown_event = get_shutdown_event()
 
@@ -30,7 +30,7 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler("../logs/series_scraper.log"),
+        logging.FileHandler(os.path.join(PROJECT_ROOT, "logs", "series_scraper.log")),
         logging.StreamHandler()
     ]
 )
@@ -40,11 +40,6 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://dontorrent.lighting/serie/"
 
 # Path to the database (shared configuration)
-try:  # pragma: no cover - compatible con ejecución como script o módulo
-    from .scraper_utils import TORRENT_DB_PATH
-except ImportError:  # pragma: no cover
-    from scraper_utils import TORRENT_DB_PATH
-
 db_path = TORRENT_DB_PATH
 
 # Count existing torrent files for a given type

--- a/Scripts/update_episodes_premiere.py
+++ b/Scripts/update_episodes_premiere.py
@@ -15,14 +15,14 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, StaleElementReferenceException
 
 # Importar utilidades compartidas
-from scraper_utils import (
+from .scraper_utils import (
     setup_logger, create_driver, connect_db, login, setup_database,
     save_progress, load_progress, clear_cache, find_series_by_title_year,
     season_exists, episode_exists, insert_series, insert_season,
     insert_episode, BASE_URL, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
     log_link_insertion, is_url_completed
 )
-from graceful_shutdown import GracefulShutdown
+from .graceful_shutdown import GracefulShutdown
 
 # Configuración específica para este script
 SCRIPT_NAME = "update_episodes_premiere"

--- a/Scripts/update_episodes_updated.py
+++ b/Scripts/update_episodes_updated.py
@@ -13,7 +13,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 
 # Importar utilidades compartidas
-from scraper_utils import (
+from .scraper_utils import (
     setup_logger, create_driver, connect_db, login, setup_database,
     save_progress, load_progress, extract_links,
     insert_links_batch, clear_cache, find_series_by_title_year,
@@ -21,7 +21,7 @@ from scraper_utils import (
     insert_episode, BASE_URL, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
     is_url_completed, mark_url_completed
 )
-from graceful_shutdown import GracefulShutdown
+from .graceful_shutdown import GracefulShutdown
 
 # Configuración específica para este script
 SCRIPT_NAME = "update_episodes_updated"

--- a/Scripts/update_movies_premiere.py
+++ b/Scripts/update_movies_premiere.py
@@ -3,15 +3,15 @@ import argparse
 import traceback
 from datetime import datetime
 
-from scraper_utils import (
+from .scraper_utils import (
     setup_logger, create_driver, login, setup_database,
     save_progress, load_progress, clear_cache,
     BASE_URL, PROJECT_ROOT, is_url_completed, mark_url_completed
 )
 
 # Reutilizamos funciones del script de películas actualizadas
-import update_movies_updated as movies_updated
-from graceful_shutdown import GracefulShutdown
+from . import update_movies_updated as movies_updated
+from .graceful_shutdown import GracefulShutdown
 
 SCRIPT_NAME = "update_movies_premiere"
 LOG_FILE = f"{SCRIPT_NAME}.log"

--- a/Scripts/update_movies_updated.py
+++ b/Scripts/update_movies_updated.py
@@ -13,13 +13,13 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, StaleElementReferenceException
 
 # Importar utilidades compartidas
-from scraper_utils import (
+from .scraper_utils import (
     setup_logger, create_driver, connect_db, login, setup_database,
     save_progress, load_progress, clear_cache, movie_exists,
     insert_or_update_movie, BASE_URL, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
     insert_links_batch, is_url_completed, mark_url_completed
 )
-from graceful_shutdown import GracefulShutdown
+from .graceful_shutdown import GracefulShutdown
 
 # Configuración específica para este script
 SCRIPT_NAME = "update_movies_updated"


### PR DESCRIPTION
## Summary
- use package-relative imports across Scripts modules to avoid ModuleNotFound errors
- standardize logging paths using PROJECT_ROOT

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c82140a2f48328bcdefc0eb5948119