### PR TITLE
Set application icon in PyInstaller spec

### DIFF
--- a/hdfull.spec
+++ b/hdfull.spec
@@ -39,6 +39,7 @@ exe = EXE(
     strip=False,
     upx=True,
     console=True,
+    icon='resources/ico.ico',
 )
 coll = COLLECT(
     exe,


### PR DESCRIPTION
## Summary
- configure the PyInstaller EXE build to use the application icon stored at resources/ico.ico

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c4615d24832895bf2e5fbb241fb4