### PR TITLE
Improve progress visibility and restart controls

### DIFF
--- a/Scripts/direct_dw_films_scraper.py
+++ b/Scripts/direct_dw_films_scraper.py
@@ -754,7 +754,10 @@ def extract_all_movies(start_page=None, db_path=None):
     global total_saved
     page_number, last_title, last_index, total_saved_local = load_progress()
     if start_page is not None:
-        page_number = start_page
+        try:
+            page_number = max(1, int(start_page))
+        except (TypeError, ValueError):
+            page_number = 1
         last_title = None
         last_index = -1
     with total_saved_lock:


### PR DESCRIPTION
## Summary
- show the last stored progress for direct scrapers, torrent scrapers and update jobs inside the GUI, and add dedicated reset buttons
- refresh progress information automatically after every run and prevent accidental database path creation by opening existing .db files
- respect manual start pages in direct and torrent scrapers by sanitising the input, trimming stored state when needed and adding CLI options for torrent scripts

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d31b151f0c8328b183ab1dd561dea7