### PR TITLE
Add database selection dialog and guard against implicit creation

### DIFF
--- a/Scripts/direct_dw_series_scraper.py
+++ b/Scripts/direct_dw_series_scraper.py
@@ -33,6 +33,7 @@ try:
         insert_season,
         insert_episode,
         BASE_URL,
+        DB_PATH,
         MAX_WORKERS,
         MAX_RETRIES,
         PROJECT_ROOT,
@@ -56,6 +57,7 @@ except ImportError:  # pragma: no cover - fallback when executed directly
         insert_season,
         insert_episode,
         BASE_URL,
+        DB_PATH,
         MAX_WORKERS,
         MAX_RETRIES,
         PROJECT_ROOT,
@@ -1644,6 +1646,18 @@ def process_all_series(start_page=None, max_pages=None, db_path=None, max_worker
     start_time = datetime.now()
     logger.info(f"Iniciando procesamiento de series: {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
 
+    if db_path:
+        db_path = os.path.abspath(db_path)
+    else:
+        db_path = DB_PATH
+
+    if not os.path.exists(db_path):
+        logger.error(
+            "La base de datos directa no existe en %s. Crea la base desde la pestaña de configuración antes de ejecutar el scraper.",
+            db_path,
+        )
+        return
+
     # Usar el número de workers especificado o el valor por defecto
     if max_workers is None:
         max_workers = MAX_WORKERS
@@ -1659,7 +1673,12 @@ def process_all_series(start_page=None, max_pages=None, db_path=None, max_worker
 
     try:
         # Configurar la base de datos
-        setup_database(logger, db_path)
+        if not setup_database(logger, db_path):
+            logger.error(
+                "No se pudo configurar la base de datos en %s. Crea la base antes de ejecutar el scraper.",
+                db_path,
+            )
+            return
 
         # Limpiar caché antes de comenzar
         clear_cache()

--- a/Scripts/scraper_utils.py
+++ b/Scripts/scraper_utils.py
@@ -302,6 +302,13 @@ def connect_db(db_path=None):
     if db_path is None:
         db_path = DB_PATH
 
+    db_path = os.path.abspath(db_path)
+
+    if db_path != ":memory:" and not os.path.exists(db_path):
+        raise FileNotFoundError(
+            f"La base de datos '{db_path}' no existe. Crea la base desde la pestaña de configuración."
+        )
+
     try:
         logging.getLogger(__name__).debug(f"Conectando a la base de datos en: {db_path}")
         connection = sqlite3.connect(db_path, timeout=30)
@@ -419,8 +426,15 @@ def setup_database(logger, db_path=None):
     """Configura la base de datos, creando tablas si no existen y añadiendo columnas necesarias."""
     if db_path is None:
         db_path = DB_PATH
+
+    db_path = os.path.abspath(db_path)
     logger.debug(f"Iniciando configuración de la base de datos en: {db_path}")
-    connection = connect_db(db_path)
+
+    try:
+        connection = connect_db(db_path)
+    except FileNotFoundError as exc:
+        logger.error(str(exc))
+        return False
     cursor = connection.cursor()
 
     try:

--- a/Scripts/update_episodes_premiere.py
+++ b/Scripts/update_episodes_premiere.py
@@ -19,7 +19,7 @@ from .scraper_utils import (
     setup_logger, create_driver, connect_db, login, setup_database,
     save_progress, load_progress, clear_cache, find_series_by_title_year,
     season_exists, episode_exists, insert_series, insert_season,
-    insert_episode, BASE_URL, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
+    insert_episode, BASE_URL, DB_PATH, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
     log_link_insertion, is_url_completed
 )
 from .graceful_shutdown import GracefulShutdown
@@ -901,8 +901,25 @@ def process_premiere_episodes(db_path=None):
     threads = []
 
     try:
+        if db_path:
+            db_path = os.path.abspath(db_path)
+        else:
+            db_path = DB_PATH
+
+        if not os.path.exists(db_path):
+            logger.error(
+                "La base de datos directa no existe en %s. Crea la base desde la pestaña de configuración antes de ejecutar el proceso.",
+                db_path,
+            )
+            return []
+
         # Configurar la base de datos
-        setup_database(logger, db_path)
+        if not setup_database(logger, db_path):
+            logger.error(
+                "No se pudo configurar la base de datos en %s. Crea la base antes de ejecutar el proceso.",
+                db_path,
+            )
+            return []
 
         # Limpiar caché antes de comenzar
         clear_cache()

--- a/Scripts/update_episodes_updated.py
+++ b/Scripts/update_episodes_updated.py
@@ -18,7 +18,7 @@ from .scraper_utils import (
     save_progress, load_progress, extract_links,
     insert_links_batch, clear_cache, find_series_by_title_year,
     season_exists, episode_exists, insert_series, insert_season,
-    insert_episode, BASE_URL, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
+    insert_episode, BASE_URL, DB_PATH, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
     is_url_completed, mark_url_completed
 )
 from .graceful_shutdown import GracefulShutdown
@@ -644,8 +644,25 @@ def process_updated_episodes(db_path=None):
     progress_data = {}
     main_driver = None
     try:
+        if db_path:
+            db_path = os.path.abspath(db_path)
+        else:
+            db_path = DB_PATH
+
+        if not os.path.exists(db_path):
+            logger.error(
+                "La base de datos directa no existe en %s. Crea la base desde la pestaña de configuración antes de ejecutar el proceso.",
+                db_path,
+            )
+            return []
+
         # Configurar la base de datos
-        setup_database(logger, db_path)
+        if not setup_database(logger, db_path):
+            logger.error(
+                "No se pudo configurar la base de datos en %s. Crea la base antes de ejecutar el proceso.",
+                db_path,
+            )
+            return []
 
         # Limpiar caché antes de comenzar
         clear_cache()

--- a/Scripts/update_movies_premiere.py
+++ b/Scripts/update_movies_premiere.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from .scraper_utils import (
     setup_logger, create_driver, login, setup_database,
     save_progress, load_progress, clear_cache,
-    BASE_URL, PROJECT_ROOT, is_url_completed, mark_url_completed
+    BASE_URL, DB_PATH, PROJECT_ROOT, is_url_completed, mark_url_completed
 )
 
 # Reutilizamos funciones del script de películas actualizadas
@@ -33,7 +33,24 @@ def process_premiere_movies(db_path=None):
     progress_data = {}
     main_driver = None
     try:
-        setup_database(logger, db_path)
+        if db_path:
+            db_path = os.path.abspath(db_path)
+        else:
+            db_path = DB_PATH
+
+        if not os.path.exists(db_path):
+            logger.error(
+                "La base de datos directa no existe en %s. Crea la base desde la pestaña de configuración antes de ejecutar el proceso.",
+                db_path,
+            )
+            return []
+
+        if not setup_database(logger, db_path):
+            logger.error(
+                "No se pudo configurar la base de datos en %s. Crea la base antes de ejecutar el proceso.",
+                db_path,
+            )
+            return []
         clear_cache()
 
         main_driver = create_driver()

--- a/Scripts/update_movies_updated.py
+++ b/Scripts/update_movies_updated.py
@@ -16,7 +16,7 @@ from selenium.common.exceptions import TimeoutException, StaleElementReferenceEx
 from .scraper_utils import (
     setup_logger, create_driver, connect_db, login, setup_database,
     save_progress, load_progress, clear_cache, movie_exists,
-    insert_or_update_movie, BASE_URL, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
+    insert_or_update_movie, BASE_URL, DB_PATH, MAX_WORKERS, MAX_RETRIES, PROJECT_ROOT,
     insert_links_batch, is_url_completed, mark_url_completed
 )
 from .graceful_shutdown import GracefulShutdown
@@ -486,8 +486,25 @@ def process_updated_movies(db_path=None):
     progress_data = {}
     main_driver = None
     try:
+        if db_path:
+            db_path = os.path.abspath(db_path)
+        else:
+            db_path = DB_PATH
+
+        if not os.path.exists(db_path):
+            logger.error(
+                "La base de datos directa no existe en %s. Crea la base desde la pestaña de configuración antes de ejecutar el proceso.",
+                db_path,
+            )
+            return []
+
         # Configurar la base de datos
-        setup_database(logger, db_path)
+        if not setup_database(logger, db_path):
+            logger.error(
+                "No se pudo configurar la base de datos en %s. Crea la base antes de ejecutar el proceso.",
+                db_path,
+            )
+            return []
 
         # Limpiar caché antes de comenzar
         clear_cache()

--- a/gui.py
+++ b/gui.py
@@ -765,40 +765,70 @@ class DatabaseTab(QWidget):
         QMessageBox.information(self, "Ruta actualizada", "Se guardó la nueva ruta de la base torrent.")
 
     def create_direct_db(self) -> None:
-        if create_direct_db(scraper_utils.DB_PATH) and scraper_utils.setup_database(self.db_logger, scraper_utils.DB_PATH):
+        selected_path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Selecciona la ubicación de la base directa",
+            scraper_utils.DB_PATH,
+            "Bases de datos (*.db);;Todos los archivos (*)",
+        )
+        if not selected_path:
+            return
+
+        if not selected_path.endswith(".db"):
+            selected_path = f"{selected_path}.db"
+        selected_path = os.path.abspath(selected_path)
+
+        if create_direct_db(selected_path) and scraper_utils.setup_database(self.db_logger, selected_path):
             try:
-                conn = connect_db(scraper_utils.DB_PATH)
+                conn = connect_db(selected_path)
                 conn.close()
+                scraper_utils.set_db_path(selected_path)
+                self.refresh_paths()
                 QMessageBox.information(
                     self,
                     "Base creada",
-                    f"La base directa se creó y verificó correctamente en:\n{scraper_utils.DB_PATH}",
+                    f"La base directa se creó y verificó correctamente en:\n{selected_path}",
                 )
-                self.log_callback(f"Base directa creada en {scraper_utils.DB_PATH}.")
+                self.log_callback(f"Base directa creada en {selected_path}.")
             except Exception as exc:  # pragma: no cover - errores de conexión
                 QMessageBox.warning(self, "Error de conexión", f"No se pudo verificar la base directa: {exc}")
-                self.log_callback(f"Error al verificar la base directa en {scraper_utils.DB_PATH}: {exc}")
+                self.log_callback(f"Error al verificar la base directa en {selected_path}: {exc}")
         else:
             QMessageBox.warning(self, "Error", "No se pudo crear la base directa.")
-            self.log_callback(f"No se pudo crear la base directa en {scraper_utils.DB_PATH}.")
+            self.log_callback(f"No se pudo crear la base directa en {selected_path}.")
 
     def create_torrent_db(self) -> None:
-        if create_torrent_db(scraper_utils.TORRENT_DB_PATH):
+        selected_path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Selecciona la ubicación de la base torrent",
+            scraper_utils.TORRENT_DB_PATH,
+            "Bases de datos (*.db);;Todos los archivos (*)",
+        )
+        if not selected_path:
+            return
+
+        if not selected_path.endswith(".db"):
+            selected_path = f"{selected_path}.db"
+        selected_path = os.path.abspath(selected_path)
+
+        if create_torrent_db(selected_path):
             try:
-                conn = sqlite3.connect(scraper_utils.TORRENT_DB_PATH)
+                conn = sqlite3.connect(selected_path)
                 conn.close()
+                scraper_utils.set_torrent_db_path(selected_path)
+                self.refresh_paths()
                 QMessageBox.information(
                     self,
                     "Base creada",
-                    f"La base torrent se creó y verificó correctamente en:\n{scraper_utils.TORRENT_DB_PATH}",
+                    f"La base torrent se creó y verificó correctamente en:\n{selected_path}",
                 )
-                self.log_callback(f"Base torrent creada en {scraper_utils.TORRENT_DB_PATH}.")
+                self.log_callback(f"Base torrent creada en {selected_path}.")
             except Exception as exc:  # pragma: no cover - errores de conexión
                 QMessageBox.warning(self, "Error de conexión", f"No se pudo verificar la base torrent: {exc}")
-                self.log_callback(f"Error al verificar la base torrent en {scraper_utils.TORRENT_DB_PATH}: {exc}")
+                self.log_callback(f"Error al verificar la base torrent en {selected_path}: {exc}")
         else:
             QMessageBox.warning(self, "Error", "No se pudo crear la base torrent.")
-            self.log_callback(f"No se pudo crear la base torrent en {scraper_utils.TORRENT_DB_PATH}.")
+            self.log_callback(f"No se pudo crear la base torrent en {selected_path}.")
 
     def create_both_db(self) -> None:
         self.create_direct_db()


### PR DESCRIPTION
## Summary
- add save file dialogs when creating direct and torrent databases from the GUI and persist the selected paths
- prevent implicit database creation by validating that the target file already exists before opening connections
- ensure scrapers and update routines stop early with clear logging when the configured database is missing

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d31fd468f48328a266de52c9c362e6